### PR TITLE
Rename crate to version-sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version-sync"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = """
 Simple crate for ensuring that version numbers in README files are

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "check-versions"
+name = "version-sync"
 version = "0.1.2"
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = """
 Simple crate for ensuring that version numbers in README files are
 updated when the crate version changes.
 """
-documentation = "https://docs.rs/check-versions/"
-repository = "https://github.com/mgeisler/check-versions"
+documentation = "https://docs.rs/version-sync/"
+repository = "https://github.com/mgeisler/version-sync"
 readme = "README.md"
 keywords = ["version"]
 categories = ["development-tools", "rust-patterns"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-versions"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = """
 Simple crate for ensuring that version numbers in README files are

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-versions"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Martin Geisler <martin@geisler.net>"]
 description = """
 Simple crate for ensuring that version numbers in README files are

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ in `dependencies` and `dev-dependencies`.
 
 ## License
 
-Textwrap can be distributed according to the [MIT license][mit].
-Contributions will be accepted under the same license.
+The `check-versions` crate can be distributed according to the [MIT
+license][mit]. Contributions will be accepted under the same license.
 
 [crates-io]: https://crates.io/crates/check-versions
 [api-docs]: https://docs.rs/check-versions/

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ This is a changelog describing the most important changes per release.
 
 ### Version 0.1.1 — September 18th, 2017
 
-The crate will be renamed to `version-sync` and this is the last
-release of the crate under the name `check-versions`.
+The crate will be renamed to [`version-sync`][version-sync] and this
+is the last release of the crate under the name `check-versions`.
 
 Version 0.1.1 is identical in functionality to version 0.1.0, except
 that using the crate will trigger a deprecation warning with
-instructions to use `version-sync` instead.
+instructions to use [`version-sync`][version-sync] instead.
 
 ### Version 0.1.0 — September 10th, 2017
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-# check-versions
+# version-sync
 
-[![](https://img.shields.io/crates/v/check-versions.svg)][crates-io]
-[![](https://docs.rs/check-versions/badge.svg)][api-docs]
-[![](https://travis-ci.org/mgeisler/check-versions.svg?branch=master)][travis-ci]
+[![](https://img.shields.io/crates/v/version-sync.svg)][crates-io]
+[![](https://docs.rs/version-sync/badge.svg)][api-docs]
+[![](https://travis-ci.org/mgeisler/version-sync.svg?branch=master)][travis-ci]
 [![](https://ci.appveyor.com/api/projects/status/hy8camtdx5iiq26l?svg=true)][appveyor]
 
-**This crate has been renamed to [`version-sync`][version-sync].
-Please update your dependencies.**
-
-The `check-versions` crate is a simple crate that will help you
+The `version-sync` crate is a simple crate that will help you
 remember to update the versions numbers in your `README.md` file.
 
 ## Usage
@@ -16,13 +13,13 @@ remember to update the versions numbers in your `README.md` file.
 Add this to your `Cargo.toml`:
 ```toml
 [dev-dependencies]
-check-versions = "0.1"
+version-sync = "0.1"
 ```
 
-Then create a `tests/check-versions.rs` with:
+Then create a `tests/version-numbers.rs` with:
 ```rust
 #[macro_use]
-extern crate check_versions;
+extern crate version_sync;
 
 #[test]
 fn test_readme_deps() {
@@ -33,9 +30,9 @@ fn test_readme_deps() {
 This test will ensure that the dependencies mentioned in your
 `README.md` file is kept in sync with your crate version:
 ```
-$ cargo test --test check-versions -- --nocapture
+$ cargo test --test version-numbers -- --nocapture
     Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
-     Running target/debug/deps/check_versions-3b40b9d452dd9385
+     Running target/debug/deps/version_numbers-3b40b9d452dd9385
 
 running 1 test
 Checking code blocks in README.md...
@@ -50,17 +47,17 @@ version number in `Cargo.toml` has been changed to 0.2.0. The test
 fails and the code block with the error is shown:
 
 ```
-$ cargo test --test check-versions -- --nocapture
+$ cargo test --test version-numbers -- --nocapture
     Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
-     Running target/debug/deps/check_versions-8fbc5f3b97f4ec3a
+     Running target/debug/deps/version_numbers-8fbc5f3b97f4ec3a
 
 running 1 test
 Checking code blocks in README.md...
 README.md (line 10) ... expected minor version 2, found 1 in
     [dev-dependencies]
-    check-versions = "0.1"
+    version-sync = "0.1"
 
-thread 'test_readme_deps' panicked at 'dependency errors in README.md', tests/check-versions.rs:6:4
+thread 'test_readme_deps' panicked at 'dependency errors in README.md', tests/version-numbers.rs:6:4
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 test test_readme_deps ... FAILED
 
@@ -71,7 +68,7 @@ failures:
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
 
-error: test failed, to rerun pass '--test check-versions'
+error: test failed, to rerun pass '--test version-numbers'
 ```
 
 ## Release History
@@ -98,12 +95,11 @@ in `dependencies` and `dev-dependencies`.
 
 ## License
 
-The `check-versions` crate can be distributed according to the [MIT
-license][mit]. Contributions will be accepted under the same license.
+Version-sync can be distributed according to the [MIT license][mit].
+Contributions will be accepted under the same license.
 
-[version-sync]: https://crates.io/crates/version-sync
-[crates-io]: https://crates.io/crates/check-versions
-[api-docs]: https://docs.rs/check-versions/
-[travis-ci]: https://travis-ci.org/mgeisler/check-versions
-[appveyor]: https://ci.appveyor.com/project/mgeisler/check-versions
+[crates-io]: https://crates.io/crates/version-sync
+[api-docs]: https://docs.rs/version-sync/
+[travis-ci]: https://travis-ci.org/mgeisler/version-sync
+[appveyor]: https://ci.appveyor.com/project/mgeisler/version-sync
 [mit]: LICENSE

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![](https://travis-ci.org/mgeisler/check-versions.svg?branch=master)][travis-ci]
 [![](https://ci.appveyor.com/api/projects/status/hy8camtdx5iiq26l?svg=true)][appveyor]
 
+**This crate has been renamed to [`version-sync`][version-sync].
+Please update your dependencies.**
+
 The `check-versions` crate is a simple crate that will help you
 remember to update the versions numbers in your `README.md` file.
 
@@ -94,6 +97,7 @@ in `dependencies` and `dev-dependencies`.
 The `check-versions` crate can be distributed according to the [MIT
 license][mit]. Contributions will be accepted under the same license.
 
+[version-sync]: https://crates.io/crates/version-sync
 [crates-io]: https://crates.io/crates/check-versions
 [api-docs]: https://docs.rs/check-versions/
 [travis-ci]: https://travis-ci.org/mgeisler/check-versions

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ error: test failed, to rerun pass '--test check-versions'
 
 This is a changelog describing the most important changes per release.
 
+### Version 0.1.2 — September 18th, 2017
+
+Identical to version 0.1.1, but with better deprecation notices.
+
 ### Version 0.1.1 — September 18th, 2017
 
 The crate will be renamed to [`version-sync`][version-sync] and this

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ error: test failed, to rerun pass '--test check-versions'
 
 This is a changelog describing the most important changes per release.
 
+### Version 0.1.1 — September 18th, 2017
+
+The crate will be renamed to `version-sync` and this is the last
+release of the crate under the name `check-versions`.
+
+Version 0.1.1 is identical in functionality to version 0.1.0, except
+that using the crate will trigger a deprecation warning with
+instructions to use `version-sync` instead.
+
 ### Version 0.1.0 — September 10th, 2017
 
 First public release with support for finding outdated version numbers

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ error: test failed, to rerun pass '--test version-numbers'
 
 This is a changelog describing the most important changes per release.
 
+### Version 0.1.3 — September 18th, 2017
+
+Idential to version 0.1.2, but release under the name `version-sync`.
+
 ### Version 0.1.2 — September 18th, 2017
 
 Identical to version 0.1.1, but with better deprecation notices.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "0.1.1", note = "please use the `version-sync` crate instead")]
 extern crate pulldown_cmark;
 extern crate toml;
 extern crate semver_parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![deprecated(since = "0.1.1", note = "please use the `version-sync` crate instead")]
 extern crate pulldown_cmark;
 extern crate toml;
 extern crate semver_parser;
@@ -213,7 +212,7 @@ pub fn check_markdown_deps(path: &str, pkg_name: &str, pkg_version: &str) -> Res
 ///
 /// ```rust,no_run
 /// #[macro_use]
-/// extern crate check_versions;
+/// extern crate version_sync;
 ///
 /// #[test]
 /// # fn fake_hidden_test_case() {}

--- a/tests/check-versions.rs
+++ b/tests/check-versions.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate check_versions;
+extern crate version_sync;
 
 #[test]
 fn test_readme_deps() {


### PR DESCRIPTION
The old name was not very description and did not describe what the crate does: it gives you tools to keep version numbers in sync.

To accomplish this, a final version 0.1.1 has been released of `check-versions`. This version is identical to version 0.1.0, except that a deprecation warning is emitted when it's used. The warning instructs users to switch to the `version-sync` crate, which has been released as version 0.1.2.